### PR TITLE
Remove escape, so special characters can be found in search

### DIFF
--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -28,11 +28,7 @@ router.get("/page/:page([0-9]+)/count/:count([0-9]+)/search/:search/operator/:op
   if (req.params.search) {
     const splitSearchParams: string[] = req.params.search.trim().split(" ");
     const operator = req.params.operator === "or" ? " | " : " & ";
-
-    searchTerm = splitSearchParams
-      .map((word) => escape(word))
-      .filter(Boolean)
-      .join(operator);
+    searchTerm = splitSearchParams.filter(Boolean).join(operator);
   }
 
   await AppDataSource.manager


### PR DESCRIPTION
The escape should be unnecessary there, since it is passed into a prepared statement, which should handle escaping, right?

Fixes #66