### PR TITLE
fix escaped code return value from walkTokenizer from

### DIFF
--- a/common/src/markdown-converter-common.ts
+++ b/common/src/markdown-converter-common.ts
@@ -136,7 +136,7 @@ export abstract class MarkdownConverter {
       .then((parsedInput) =>
         this.dompurify.sanitize(parsedInput, {
           // Allowed tags and attributes inside markdown
-          ADD_TAGS: ["iframe"],
+          ADD_TAGS: ["iframe", "foreignObject"], // foreignObject is needed for SVGs that show html tags inside them like mermaid-diagrams
           ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling"],
         }),
       );

--- a/common/src/markdown-converter-common.ts
+++ b/common/src/markdown-converter-common.ts
@@ -105,6 +105,9 @@ export abstract class MarkdownConverter {
         if (token.type === "image") {
           token.href = (await this.f?.(token.href).catch(() => undefined)) ?? token.href;
         }
+        if (token.type === "code") {
+          token.escaped = true;
+        }
       },
     });
     marked.use(MarkdownConverter.rendererExtension);


### PR DESCRIPTION
seems that after the marked update the code gets returned escaped by marked.parse().